### PR TITLE
Add IE11 relatedTarget fix

### DIFF
--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -62,7 +62,7 @@
               @click="clickHandler(option)" :aria-selected="isSelected(option) ? 'true': 'false'"
               )
               slot(
-                name="option" 
+                name="option"
                 :option="option"
                 :value="value"
                 )
@@ -292,12 +292,16 @@ export default {
       }
     },
     buttonBlurHandler(e) {
-      if (e.relatedTarget !== this.$refs.list && this.open) {
+      let target = e.relatedTarget;
+      if (target === null) { target = document.activeElement; }
+      if (target !== this.$refs.list && this.open) {
         this.open = false
       }
     },
     menuBlurHandler(e) {
-      if (e.relatedTarget !== this.$refs.button) {
+      let target = e.relatedTarget;
+      if (target === null) { target = document.activeElement; }
+      if (target !== this.$refs.button) {
         this.open = false
       }
     },


### PR DESCRIPTION
Hello. I needed to support IE11 and noticed a small bug that was causing the select-box to close immediately after opening.

I poked around and found some issues related to IE11 and `event.relatedTarget`, I stumbled across [this solution from stack overflow](https://stackoverflow.com/questions/41298948/how-to-use-relatedtarget-or-equivalent-in-ie), forked the repo, tested it and it seems to work.

Thanks for creating this project @andrewvasilchuk !