### PR TITLE
Fix keyboard navigation

### DIFF
--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -215,6 +215,7 @@ export default {
       const { currentOptionIndex, open } = this
 
       switch (e.keyCode) {
+        // Arrow up
         case 38:
           if (!open) {
             return this.toggle()
@@ -223,6 +224,7 @@ export default {
           if (currentOptionIndex > 0)
             this.emit(this.options[currentOptionIndex - 1].value)
           return
+        // Arrow down
         case 40:
           if (!open) {
             return this.toggle()
@@ -231,6 +233,7 @@ export default {
           if (currentOptionIndex !== this.options.length - 1)
             this.emit(this.options[currentOptionIndex + 1].value)
           return
+        // Enter
         case 13:
           setTimeout(() => {
             this.open = false

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -261,13 +261,17 @@ export default {
       this.selectByText(this.printedText)
 
       clearTimeout(this.timeout)
+      this.timeout = null
 
       this.timeout = setTimeout(() => {
         this.printedText = ''
       }, 500)
     },
     selectByText(text) {
-      for (let option of this.options) {
+      const { options, value } = this
+      const selectedIndex = options.findIndex(o => o.value === value)
+
+      for (let option of this.shiftOptions(selectedIndex)) {
         if (
           String(option.label)
             .toUpperCase()
@@ -310,6 +314,21 @@ export default {
     },
     hasSlot(name) {
       return Boolean(this.$slots[name]) || Boolean(this.$scopedSlots[name])
+    },
+    shiftOptions(selectedIndex) {
+      const { options } = this
+
+      if (selectedIndex === -1 || this.timeout) {
+        return options
+      }
+
+      const optionsBeforeSelected = options.slice(0, selectedIndex - 1)
+      const optionsAfterSelected = options.slice(
+        selectedIndex + 1,
+        options.length
+      )
+
+      return [...optionsAfterSelected, ...optionsBeforeSelected]
     },
   },
 }

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -253,7 +253,10 @@ export default {
       this.$refs.button.focus()
     },
     printHandler(e) {
-      this.printedText += String.fromCharCode(e.keyCode)
+      const newChar = e.key ? e.key : String.fromCharCode(e.keyCode)
+      if (newChar.length > 1) return
+
+      this.printedText += newChar.toUpperCase()
 
       this.selectByText(this.printedText)
 

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -62,7 +62,7 @@
               @click="clickHandler(option)" :aria-selected="isSelected(option) ? 'true': 'false'"
               )
               slot(
-                name="option" 
+                name="option"
                 :option="option"
                 :value="value"
                 )
@@ -130,8 +130,10 @@ export default {
       return this.options.findIndex(option => option === this.currentOption)
     },
     optionsHasValue() {
-      return this.options.findIndex(option => option.value === this.value) !== -1
-    }
+      return (
+        this.options.findIndex(option => option.value === this.value) !== -1
+      )
+    },
   },
   watch: {
     open(val) {
@@ -268,10 +270,7 @@ export default {
       }, 500)
     },
     selectByText(text) {
-      const { options, value } = this
-      const selectedIndex = options.findIndex(o => o.value === value)
-
-      for (let option of this.shiftOptions(selectedIndex)) {
+      for (let option of this.shiftOptions(this.currentOptionIndex)) {
         if (
           String(option.label)
             .toUpperCase()

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -215,6 +215,10 @@ export default {
       const { currentOptionIndex, open } = this
 
       switch (e.keyCode) {
+        // Space
+        case 32:
+          if (!this.open) return (this.open = true)
+          break
         // Arrow up
         case 38:
           if (!open) {

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -16,6 +16,7 @@
         aria-haspopup="listbox"
         @click="toggle"
         @blur="buttonBlurHandler"
+        @keydown="keydownHandler"
         )
         span.v-select__prepend(v-if="hasSlot('prepend')")
           slot(name="prepend")
@@ -51,7 +52,6 @@
             @keyup.35="setLastSelected"
             @keyup.36="setFirstSelected"
             @keyup.esc="escapeHandler"
-            @keyup="printHandler"
             @blur="menuBlurHandler"
             )
             li.v-select__option(
@@ -210,30 +210,34 @@ export default {
         e.preventDefault()
       }
 
-      const { currentOptionIndex } = this
-      // if neither option is selected then select the first
-
-      if (currentOptionIndex === -1) {
-        this.emit(this.options[0].value)
-        return
-      }
+      const { currentOptionIndex, open } = this
 
       switch (e.keyCode) {
         case 38:
-          if (currentOptionIndex !== 0)
+          if (!open) {
+            return this.toggle()
+          }
+
+          if (currentOptionIndex > 0)
             this.emit(this.options[currentOptionIndex - 1].value)
-          break
+          return
         case 40:
+          if (!open) {
+            return this.toggle()
+          }
+
           if (currentOptionIndex !== this.options.length - 1)
             this.emit(this.options[currentOptionIndex + 1].value)
-          break
+          return
         case 13:
           setTimeout(() => {
             this.open = false
             this.$refs.button.focus()
           }, 0)
-          break
+          return
       }
+
+      this.printHandler(e)
     },
     getOptionId(option) {
       return `v-select-option-${this.options.indexOf(option)}_${this.localId_}`

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -151,7 +151,7 @@ export default {
       if (this.timeout) options.unshift(this.currentOption)
 
       return options
-   
+    },
   },
   watch: {
     open(val) {
@@ -324,15 +324,19 @@ export default {
       }
     },
     buttonBlurHandler(e) {
-      let target = e.relatedTarget;
-      if (target === null) { target = document.activeElement; }
+      let target = e.relatedTarget
+      if (target === null) {
+        target = document.activeElement
+      }
       if (target !== this.$refs.list && this.open) {
         this.open = false
       }
     },
     menuBlurHandler(e) {
-      let target = e.relatedTarget;
-      if (target === null) { target = document.activeElement; }
+      let target = e.relatedTarget
+      if (target === null) {
+        target = document.activeElement
+      }
       if (target !== this.$refs.button) {
         this.open = false
       }

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -134,6 +134,24 @@ export default {
         this.options.findIndex(option => option.value === this.value) !== -1
       )
     },
+    /** this.options, shifed to have the element after the selected one first */
+    shiftedOptions() {
+      if (this.currentOptionIndex === -1) {
+        return this.options
+      }
+
+      const beforeSelected = this.options.slice(0, this.currentOptionIndex - 1)
+      const afterSelected = this.options.slice(
+        this.currentOptionIndex + 1,
+        this.options.length
+      )
+
+      const options = [...afterSelected, ...beforeSelected]
+
+      if (this.timeout) options.unshift(this.currentOption)
+
+      return options
+    },
   },
   watch: {
     open(val) {
@@ -267,15 +285,14 @@ export default {
 
       this.selectByText(this.printedText)
 
-      clearTimeout(this.timeout)
-      this.timeout = null
-
       this.timeout = setTimeout(() => {
         this.printedText = ''
+        clearTimeout(this.timeout)
+        this.timeout = null
       }, 500)
     },
     selectByText(text) {
-      for (let option of this.shiftOptions(this.currentOptionIndex)) {
+      for (let option of this.shiftedOptions) {
         if (
           String(option.label)
             .toUpperCase()
@@ -318,21 +335,6 @@ export default {
     },
     hasSlot(name) {
       return Boolean(this.$slots[name]) || Boolean(this.$scopedSlots[name])
-    },
-    shiftOptions(selectedIndex) {
-      const { options } = this
-
-      if (selectedIndex === -1 || this.timeout) {
-        return options
-      }
-
-      const optionsBeforeSelected = options.slice(0, selectedIndex - 1)
-      const optionsAfterSelected = options.slice(
-        selectedIndex + 1,
-        options.length
-      )
-
-      return [...optionsAfterSelected, ...optionsBeforeSelected]
     },
   },
 }

--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -221,24 +221,22 @@ export default {
           break
         // Arrow up
         case 38:
-          if (!open) {
-            return this.toggle()
-          }
+          if (!open) return (this.open = true)
 
           if (currentOptionIndex > 0)
             this.emit(this.options[currentOptionIndex - 1].value)
           return
         // Arrow down
         case 40:
-          if (!open) {
-            return this.toggle()
-          }
+          if (!open) return (this.open = true)
 
           if (currentOptionIndex !== this.options.length - 1)
             this.emit(this.options[currentOptionIndex + 1].value)
           return
         // Enter
         case 13:
+          if (!this.open) return
+
           setTimeout(() => {
             this.open = false
             this.$refs.button.focus()


### PR DESCRIPTION
Hello.

I noticed that this library has a few flaws regarding keyboard accessibility, and I've done my best to fix them here :)

Fixed issues:
 - Type-ahead
     - [ ] Would always select the **first** matching option, rather than the **next** matching option, like a native select would.
     - [ ] Had problems when you would use the spacebar for a multi-word option
 - General keyboard navigation
     - [x] Arrow keys and type-ahead didn't work without opening the select first - this doesn't match with native select behavior either