### PR TITLE
Prevent aria-expanded from disappearing when the dropdown is closed

### DIFF
--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -62,7 +62,7 @@
               @click="clickHandler(option)" :aria-selected="isSelected(option) ? 'true': 'false'"
               )
               slot(
-                name="option" 
+                name="option"
                 :option="option"
                 :value="value"
                 )
@@ -112,7 +112,7 @@ export default {
       return `v-select-button-${this.localId_}`
     },
     ariaExpanded() {
-      return this.open ? 'true' : false
+      return this.open ? 'true' : 'false'
     },
     className() {
       return {
@@ -130,8 +130,10 @@ export default {
       return this.options.findIndex(option => option === this.currentOption)
     },
     optionsHasValue() {
-      return this.options.findIndex(option => option.value === this.value) !== -1
-    }
+      return (
+        this.options.findIndex(option => option.value === this.value) !== -1
+      )
+    },
   },
   watch: {
     open(val) {


### PR DESCRIPTION
The aria-expanded attribute disappears when the dropdown is closed; this is wrong behavior, as it should always be present for a listbox. This is fixed here :)