### PR TITLE
Fix no-options slot name correctly

### DIFF
--- a/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
+++ b/src/components/VueAccessibleSelect/VueAccessibleSelect.vue
@@ -69,7 +69,7 @@
                 span {{ option.label }}
           template(v-else)
             .v-select__no-options
-              slot(name="no-optioms")
+              slot(name="no-options")
                 span No options provided
 </template>
 


### PR DESCRIPTION
The no-options slot name is incorrectly `no-optioms` in the code. This fixes that to `no-options`.